### PR TITLE
Packages and LineBreaks. Datetime and AuthTokens

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+
+* text=auto

--- a/Maestri.Back/Pipfile
+++ b/Maestri.Back/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+django = "*"
+djangorestframework = "*"
+black = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.12"

--- a/Maestri.Back/Pipfile
+++ b/Maestri.Back/Pipfile
@@ -8,6 +8,7 @@ django = "*"
 djangorestframework = "*"
 black = "*"
 requests = "*"
+pytz = "*"
 
 [dev-packages]
 

--- a/Maestri.Back/Pipfile
+++ b/Maestri.Back/Pipfile
@@ -7,8 +7,9 @@ name = "pypi"
 django = "*"
 djangorestframework = "*"
 black = "*"
+requests = "*"
 
 [dev-packages]
 
 [requires]
-python_version = "3.12"
+python_version = "3"

--- a/Maestri.Back/Pipfile.lock
+++ b/Maestri.Back/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e34a82a707bd9369651a3aebdd1e862856da29a7844e30d7aec56ffc48aab47b"
+            "sha256": "ab17659e0d5cf41cd57dcc85f7456073cef0fe9ef7f49e240b7e2830c2297b82"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -165,6 +165,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
         },
+        "colorama": {
+            "hashes": [
+                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            ],
+            "markers": "platform_system == 'Windows'",
+            "version": "==0.4.6"
+        },
         "django": {
             "hashes": [
                 "sha256:8c8659665bc6e3a44fefe1ab0a291e5a3fb3979f9a8230be29de975e57e8f854",
@@ -228,6 +236,7 @@
                 "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b",
                 "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"
             ],
+            "index": "pypi",
             "version": "==2023.3.post1"
         },
         "requests": {
@@ -247,21 +256,13 @@
             "markers": "python_version >= '3.5'",
             "version": "==0.4.4"
         },
-        "tomli": {
+        "tzdata": {
             "hashes": [
-                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
-                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+                "sha256:aa3ace4329eeacda5b7beb7ea08ece826c28d761cda36e747cfbf97996d39bf3",
+                "sha256:dd54c94f294765522c77399649b4fefd95522479a664a0cec87f41bebc6148c9"
             ],
-            "markers": "python_version < '3.11'",
-            "version": "==2.0.1"
-        },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783",
-                "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"
-            ],
-            "markers": "python_version < '3.11'",
-            "version": "==4.9.0"
+            "markers": "sys_platform == 'win32'",
+            "version": "==2023.4"
         },
         "urllib3": {
             "hashes": [

--- a/Maestri.Back/Pipfile.lock
+++ b/Maestri.Back/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "81a68cda966cd70549b495069975649a2df19853de9243a920fad897ee8d718c"
+            "sha256": "e34a82a707bd9369651a3aebdd1e862856da29a7844e30d7aec56ffc48aab47b"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.12"
+            "python_version": "3"
         },
         "sources": [
             {
@@ -53,6 +53,110 @@
             "markers": "python_version >= '3.8'",
             "version": "==23.12.1"
         },
+        "certifi": {
+            "hashes": [
+                "sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
+                "sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2023.11.17"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027",
+                "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087",
+                "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786",
+                "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8",
+                "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09",
+                "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185",
+                "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574",
+                "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e",
+                "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519",
+                "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898",
+                "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269",
+                "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3",
+                "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f",
+                "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6",
+                "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8",
+                "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a",
+                "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73",
+                "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc",
+                "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714",
+                "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2",
+                "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc",
+                "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce",
+                "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d",
+                "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e",
+                "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6",
+                "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269",
+                "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96",
+                "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d",
+                "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a",
+                "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4",
+                "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77",
+                "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d",
+                "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0",
+                "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed",
+                "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068",
+                "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac",
+                "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25",
+                "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8",
+                "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab",
+                "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26",
+                "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2",
+                "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db",
+                "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f",
+                "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5",
+                "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99",
+                "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c",
+                "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d",
+                "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811",
+                "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa",
+                "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a",
+                "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03",
+                "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b",
+                "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04",
+                "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c",
+                "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001",
+                "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458",
+                "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389",
+                "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99",
+                "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985",
+                "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537",
+                "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238",
+                "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f",
+                "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d",
+                "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796",
+                "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a",
+                "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143",
+                "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8",
+                "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c",
+                "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5",
+                "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5",
+                "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711",
+                "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4",
+                "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6",
+                "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c",
+                "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7",
+                "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4",
+                "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b",
+                "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae",
+                "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12",
+                "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c",
+                "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae",
+                "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8",
+                "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887",
+                "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b",
+                "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4",
+                "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f",
+                "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
+                "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33",
+                "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519",
+                "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==3.3.2"
+        },
         "click": {
             "hashes": [
                 "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
@@ -60,14 +164,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
-                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
-            ],
-            "markers": "platform_system == 'Windows'",
-            "version": "==0.4.6"
         },
         "django": {
             "hashes": [
@@ -86,6 +182,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.6'",
             "version": "==3.14.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
+                "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.6"
         },
         "mypy-extensions": {
             "hashes": [
@@ -126,6 +230,15 @@
             ],
             "version": "==2023.3.post1"
         },
+        "requests": {
+            "hashes": [
+                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
+                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==2.31.0"
+        },
         "sqlparse": {
             "hashes": [
                 "sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3",
@@ -134,13 +247,29 @@
             "markers": "python_version >= '3.5'",
             "version": "==0.4.4"
         },
-        "tzdata": {
+        "tomli": {
             "hashes": [
-                "sha256:aa3ace4329eeacda5b7beb7ea08ece826c28d761cda36e747cfbf97996d39bf3",
-                "sha256:dd54c94f294765522c77399649b4fefd95522479a664a0cec87f41bebc6148c9"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==2023.4"
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783",
+                "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==4.9.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3",
+                "sha256:df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.1.0"
         }
     },
     "develop": {}

--- a/Maestri.Back/Pipfile.lock
+++ b/Maestri.Back/Pipfile.lock
@@ -1,0 +1,147 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "81a68cda966cd70549b495069975649a2df19853de9243a920fad897ee8d718c"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.12"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "asgiref": {
+            "hashes": [
+                "sha256:89b2ef2247e3b562a16eef663bc0e2e703ec6468e2fa8a5cd61cd449786d4f6e",
+                "sha256:9e0ce3aa93a819ba5b45120216b23878cf6e8525eb3848653452b4192b92afed"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.7.2"
+        },
+        "black": {
+            "hashes": [
+                "sha256:0808494f2b2df923ffc5723ed3c7b096bd76341f6213989759287611e9837d50",
+                "sha256:1fa88a0f74e50e4487477bc0bb900c6781dbddfdfa32691e780bf854c3b4a47f",
+                "sha256:25e57fd232a6d6ff3f4478a6fd0580838e47c93c83eaf1ccc92d4faf27112c4e",
+                "sha256:2d9e13db441c509a3763a7a3d9a49ccc1b4e974a47be4e08ade2a228876500ec",
+                "sha256:3e1b38b3135fd4c025c28c55ddfc236b05af657828a8a6abe5deec419a0b7055",
+                "sha256:3fa4be75ef2a6b96ea8d92b1587dd8cb3a35c7e3d51f0738ced0781c3aa3a5a3",
+                "sha256:4ce3ef14ebe8d9509188014d96af1c456a910d5b5cbf434a09fef7e024b3d0d5",
+                "sha256:4f0031eaa7b921db76decd73636ef3a12c942ed367d8c3841a0739412b260a54",
+                "sha256:602cfb1196dc692424c70b6507593a2b29aac0547c1be9a1d1365f0d964c353b",
+                "sha256:6d1bd9c210f8b109b1762ec9fd36592fdd528485aadb3f5849b2740ef17e674e",
+                "sha256:78baad24af0f033958cad29731e27363183e140962595def56423e626f4bee3e",
+                "sha256:8d4df77958a622f9b5a4c96edb4b8c0034f8434032ab11077ec6c56ae9f384ba",
+                "sha256:97e56155c6b737854e60a9ab1c598ff2533d57e7506d97af5481141671abf3ea",
+                "sha256:9c4352800f14be5b4864016882cdba10755bd50805c95f728011bcb47a4afd59",
+                "sha256:a4d6a9668e45ad99d2f8ec70d5c8c04ef4f32f648ef39048d010b0689832ec6d",
+                "sha256:a920b569dc6b3472513ba6ddea21f440d4b4c699494d2e972a1753cdc25df7b0",
+                "sha256:ae76c22bde5cbb6bfd211ec343ded2163bba7883c7bc77f6b756a1049436fbb9",
+                "sha256:b18fb2ae6c4bb63eebe5be6bd869ba2f14fd0259bda7d18a46b764d8fb86298a",
+                "sha256:c04b6d9d20e9c13f43eee8ea87d44156b8505ca8a3c878773f68b4e4812a421e",
+                "sha256:c88b3711d12905b74206227109272673edce0cb29f27e1385f33b0163c414bba",
+                "sha256:dd15245c8b68fe2b6bd0f32c1556509d11bb33aec9b5d0866dd8e2ed3dba09c2",
+                "sha256:e0aaf6041986767a5e0ce663c7a2f0e9eaf21e6ff87a5f95cbf3675bfd4c41d2"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==23.12.1"
+        },
+        "click": {
+            "hashes": [
+                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.7"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            ],
+            "markers": "platform_system == 'Windows'",
+            "version": "==0.4.6"
+        },
+        "django": {
+            "hashes": [
+                "sha256:8c8659665bc6e3a44fefe1ab0a291e5a3fb3979f9a8230be29de975e57e8f854",
+                "sha256:f47a37a90b9bbe2c8ec360235192c7fddfdc832206fcf618bb849b39256affc1"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==5.0.1"
+        },
+        "djangorestframework": {
+            "hashes": [
+                "sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8",
+                "sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.6'",
+            "version": "==3.14.0"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+                "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
+                "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.2"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08",
+                "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.12.1"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:11c8f37bcca40db96d8144522d925583bdb7a31f7b0e37e3ed4318400a8e2380",
+                "sha256:906d548203468492d432bcb294d4bc2fff751bf84971fbb2c10918cc206ee420"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.1.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b",
+                "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"
+            ],
+            "version": "==2023.3.post1"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3",
+                "sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==0.4.4"
+        },
+        "tzdata": {
+            "hashes": [
+                "sha256:aa3ace4329eeacda5b7beb7ea08ece826c28d761cda36e747cfbf97996d39bf3",
+                "sha256:dd54c94f294765522c77399649b4fefd95522479a664a0cec87f41bebc6148c9"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==2023.4"
+        }
+    },
+    "develop": {}
+}

--- a/Maestri.Back/api/api_base/urls.py
+++ b/Maestri.Back/api/api_base/urls.py
@@ -4,6 +4,6 @@ from django.urls import path, include
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("pix/", include("pix.urls")),
-    path("pix_slip/", include("pix_slip.urls")),
+    path("pix-slip/", include("pix_slip.urls")),
     path("hook/", include("hook.urls")),
 ]

--- a/Maestri.Back/api/pix/views.py
+++ b/Maestri.Back/api/pix/views.py
@@ -1,7 +1,6 @@
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from apps.pix.pix_payment import PixPayment
-from common.enums.request_type import RequestType
 from common.contracts.pix.create_pix_payment import CreatePixPayment
 from common.contracts.pix.pix_payment_response import PixPaymentResponse
 from common.factories.pix_factory import PixServiceFactory
@@ -15,6 +14,15 @@ def create_payment(request):
     return Response(result.request)
 
 
+@api_view(["POST"])
+def payment_response(request):
+    response = []
+    for data in request.data:
+        request_data = PixPaymentResponse.create(data)
+        response.append(request_data.json_request_body())
+    return Response(response)
+
+
 @api_view(["GET"])
 def get_payments(request):
     request_data = "get"
@@ -24,9 +32,3 @@ def get_payments(request):
 @api_view(["GET"])
 def get_payment(request, id: int):
     return Response(f"get_by_id {id}")
-
-
-@api_view(["POST"])
-def payment_response(request):
-    request_data = PixPaymentResponse.create(request.data)
-    return Response(request.data)

--- a/Maestri.Back/api/pix_slip/urls.py
+++ b/Maestri.Back/api/pix_slip/urls.py
@@ -1,4 +1,7 @@
 from django.urls import path
 from . import views
 
-urlpatterns = [path("payment", views.create_payment)]
+urlpatterns = [
+    path("payment", views.create_payment),
+    path("payment-response", views.payment_response),
+]

--- a/Maestri.Back/api/pix_slip/views.py
+++ b/Maestri.Back/api/pix_slip/views.py
@@ -2,6 +2,7 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from apps.pix_slip.pix_slip_payment import PixSlipPayment
 from common.contracts.pix_slip.create_pix_slip_payment import CreatePixSlipPayment
+from common.contracts.pix_slip.pix_slip_payment_response import PixSlipPaymentResponse
 from common.factories.pix_slip_factory import PixSlipServiceFactory
 
 
@@ -11,3 +12,12 @@ def create_payment(request):
     pix_slip_payment = PixSlipPayment(PixSlipServiceFactory.create())
     result = pix_slip_payment.create_payment(request_data)
     return Response(result.request)
+
+
+@api_view(["POST"])
+def payment_response(request):
+    response = []
+    for data in request.data:
+        request_data = PixSlipPaymentResponse.create(data)
+        response.append(request_data.json_request_body())
+    return Response(response)

--- a/Maestri.Back/apps/pix/pix_payment.py
+++ b/Maestri.Back/apps/pix/pix_payment.py
@@ -12,11 +12,13 @@ class PixPayment:
 
     def create_payment(self, request: CreatePixPayment):
         payment = PixPaymentModel(
-            Debtor(request.payer_name, request.payer_id, PersonType.PF),
-            Value(request.payment_value, 1),
-            Calendar(request.expire_seconds),
-            "key",
-            request.solicitation,
+            debtor=Debtor(
+                id_code=request.payer_id, name=request.payer_name, type=PersonType.PF
+            ),
+            value=Value(request.payment_value, 1),
+            calendar=Calendar(request.expire_seconds),
+            key="key",
+            solicitation=request.solicitation,
         )
 
         return self._pay.emit_payment(payment)

--- a/Maestri.Back/apps/pix/pix_payment.py
+++ b/Maestri.Back/apps/pix/pix_payment.py
@@ -16,7 +16,7 @@ class PixPayment:
                 id_code=request.payer_id, name=request.payer_name, type=PersonType.PF
             ),
             value=Value(request.payment_value, 1),
-            calendar=Calendar(request.expire_seconds),
+            calendar=Calendar(86400),
             key="key",
             solicitation=request.solicitation,
         )

--- a/Maestri.Back/apps/pix_slip/pix_slip_payment.py
+++ b/Maestri.Back/apps/pix_slip/pix_slip_payment.py
@@ -13,24 +13,24 @@ class PixSlipPayment:
 
     def create_payment(self, request: CreatePixSlipPayment):
         payment = PixSlipPaymentModel(
-            "80",
-            request.payment_value,
-            request.due_date,
-            request.due_date_limit,
-            PayerModel(
-                request.payer_id,
-                request.payer_name,
-                "email",
-                PersonType.PF,
-                Telephone("ddd", "number"),
-                Address(
-                    "cep",
-                    "complete Adress",
-                    UF.PR,
-                    "city",
-                    "neighborhood",
-                    "ab1",
-                    "complement",
+            title_number="80",
+            value=request.payment_value,
+            due_date=request.due_date,
+            due_date_spare_limit=request.due_date_limit,
+            payer=PayerModel(
+                id_number=request.payer_id,
+                name=request.payer_name,
+                email="email",
+                type=PersonType.PF,
+                telephone=Telephone("ddd", "number"),
+                adress=Address(
+                    cep_number="cep",
+                    complete_adress="complete Adress",
+                    uf=UF.PR,
+                    city="city",
+                    neighborhood="neighborhood",
+                    number="ab1",
+                    complement="complement",
                 ),
             ),
         )

--- a/Maestri.Back/apps/pix_slip/pix_slip_payment.py
+++ b/Maestri.Back/apps/pix_slip/pix_slip_payment.py
@@ -3,6 +3,8 @@ from common.enums.person_enums import PersonType, UF
 from models.common.payer_model import PayerModel, Telephone, Address
 from models.pix_slip.pix_slip_payment_model import PixSlipPaymentModel
 from services.pix_slip.pix_slip_service import PixSlipService
+from common.helper.datetime_provider import DatetimeProvider as dt
+import datetime
 
 
 class PixSlipPayment:
@@ -12,11 +14,13 @@ class PixSlipPayment:
         self._pix_slip = pix_slip
 
     def create_payment(self, request: CreatePixSlipPayment):
+        request_due_date = dt.utc_now() + datetime.timedelta(days=30)
+
         payment = PixSlipPaymentModel(
             title_number="80",
             value=request.payment_value,
-            due_date=request.due_date,
-            due_date_spare_limit=request.due_date_limit,
+            due_date=request_due_date,
+            due_date_spare_limit=7,
             payer=PayerModel(
                 id_number=request.payer_id,
                 name=request.payer_name,

--- a/Maestri.Back/common/contracts/hook/create_pix_hook.py
+++ b/Maestri.Back/common/contracts/hook/create_pix_hook.py
@@ -7,4 +7,4 @@ class CreatePixWebHook:
 
     @staticmethod
     def create(data: dict):
-        return CreatePixWebHook(data["hook_url"])
+        return CreatePixWebHook(hook_url=data["hook_url"])

--- a/Maestri.Back/common/contracts/hook/create_pix_slip_hook.py
+++ b/Maestri.Back/common/contracts/hook/create_pix_slip_hook.py
@@ -7,4 +7,4 @@ class CreatePixSlipWebHook:
 
     @staticmethod
     def create(data: dict):
-        return CreatePixSlipWebHook(data["hook_url"])
+        return CreatePixSlipWebHook(hook_url=data["hook_url"])

--- a/Maestri.Back/common/contracts/pix/create_pix_payment.py
+++ b/Maestri.Back/common/contracts/pix/create_pix_payment.py
@@ -6,7 +6,6 @@ class CreatePixPayment:
     payment_value: float
     payer_id: str
     payer_name: str
-    expire_seconds: int
     solicitation: str
 
     @staticmethod
@@ -15,6 +14,5 @@ class CreatePixPayment:
             payment_value=data["payment_value"],
             payer_id=data["payer_id"],
             payer_name=data["payer_name"],
-            expire_seconds=data["expire_seconds"],
             solicitation=data["solicitation"],
         )

--- a/Maestri.Back/common/contracts/pix/create_pix_payment.py
+++ b/Maestri.Back/common/contracts/pix/create_pix_payment.py
@@ -12,9 +12,9 @@ class CreatePixPayment:
     @staticmethod
     def create(data: dict):
         return CreatePixPayment(
-            data["payment_value"],
-            data["payer_name"],
-            data["payer_id"],
-            data["expire_seconds"],
-            data["solicitation"],
+            payment_value=data["payment_value"],
+            payer_id=data["payer_id"],
+            payer_name=data["payer_name"],
+            expire_seconds=data["expire_seconds"],
+            solicitation=data["solicitation"],
         )

--- a/Maestri.Back/common/contracts/pix/pix_payment_response.py
+++ b/Maestri.Back/common/contracts/pix/pix_payment_response.py
@@ -15,13 +15,13 @@ class PixPaymentResponse:
     @staticmethod
     def create(data: dict):
         return PixPaymentResponse(
-            data["endToEndId"],
-            data["chave"],
-            data["componentesValor"]["original"]["valor"],
-            data["txid"],
-            data["valor"],
-            data["horario"],
-            data["infoPagado"],
+            id=data["endToEndId"],
+            key=data["chave"],
+            txid=data["txid"],
+            original_value=data["componentesValor"]["original"]["valor"],
+            payment_value=data["valor"],
+            payment_datetime=data["horario"],
+            payer_info=data["infoPagador"],
         )
 
     def json_request_body(self):

--- a/Maestri.Back/common/contracts/pix/pix_payment_response.py
+++ b/Maestri.Back/common/contracts/pix/pix_payment_response.py
@@ -20,7 +20,7 @@ class PixPaymentResponse:
             txid=data["txid"],
             original_value=data["componentesValor"]["original"]["valor"],
             payment_value=data["valor"],
-            payment_datetime=data["horario"],
+            payment_datetime=datetime.fromisoformat(data["horario"]),
             payer_info=data["infoPagador"],
         )
 

--- a/Maestri.Back/common/contracts/pix_slip/create_pix_slip_payment.py
+++ b/Maestri.Back/common/contracts/pix_slip/create_pix_slip_payment.py
@@ -7,8 +7,6 @@ class CreatePixSlipPayment:
     payment_value: float
     payer_id: str
     payer_name: str
-    due_date: datetime
-    due_date_limit: int
 
     @staticmethod
     def create(data: dict):
@@ -16,6 +14,4 @@ class CreatePixSlipPayment:
             payment_value=data["payment_value"],
             payer_id=data["payer_id"],
             payer_name=data["payer_name"],
-            due_date=datetime.now(),
-            due_date_limit=1,
         )

--- a/Maestri.Back/common/contracts/pix_slip/create_pix_slip_payment.py
+++ b/Maestri.Back/common/contracts/pix_slip/create_pix_slip_payment.py
@@ -13,9 +13,9 @@ class CreatePixSlipPayment:
     @staticmethod
     def create(data: dict):
         return CreatePixSlipPayment(
-            data["payment_value"],
-            data["payer_id"],
-            data["payer_name"],
-            datetime.now(),
-            1,
+            payment_value=data["payment_value"],
+            payer_id=data["payer_id"],
+            payer_name=data["payer_name"],
+            due_date=datetime.now(),
+            due_date_limit=1,
         )

--- a/Maestri.Back/common/contracts/pix_slip/pix_slip_payment_response.py
+++ b/Maestri.Back/common/contracts/pix_slip/pix_slip_payment_response.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 @dataclass
 class PixSlipPaymentResponse:
-    charge_code: str
     solicitaion_code: str
     account_number: str
     status: str
@@ -20,15 +19,14 @@ class PixSlipPaymentResponse:
     @staticmethod
     def create(data: dict):
         return PixSlipPaymentResponse(
-            charge_code=data["codigoCobrança"],
             solicitaion_code=data["codigoSolicitacao"],
             account_number=data["seuNumero"],
             status=data["situacao"],
-            received_datetime=data["dataHoraSituacao"],
+            received_datetime=datetime.fromisoformat(data["dataHoraSituacao"]),
             received_value=data["valorTotalRecebido"],
             payment_origin=data["origemRecebimento"],
             bank_number=data["nossoNumero"],
-            bar_code=data["condigoBarras"],
+            bar_code=data["codigoBarras"],
             typed_code=data["linhaDigitavel"],
             txid=data["txid"],
             simple_pix_code=data["pixCopiaECola"],
@@ -36,7 +34,6 @@ class PixSlipPaymentResponse:
 
     def json_request_body(self):
         return {
-            "codigoCobranca": self.charge_code,
             "codigoSolicitacao": self.solicitaion_code,
             "seuNumero": self.account_number,
             "situacao": self.status,

--- a/Maestri.Back/common/contracts/pix_slip/pix_slip_payment_response.py
+++ b/Maestri.Back/common/contracts/pix_slip/pix_slip_payment_response.py
@@ -17,6 +17,23 @@ class PixSlipPaymentResponse:
     txid: str
     simple_pix_code: str
 
+    @staticmethod
+    def create(data: dict):
+        return PixSlipPaymentResponse(
+            charge_code=data["codigoCobrança"],
+            solicitaion_code=data["codigoSolicitacao"],
+            account_number=data["seuNumero"],
+            status=data["situacao"],
+            received_datetime=data["dataHoraSituacao"],
+            received_value=data["valorTotalRecebido"],
+            payment_origin=data["origemRecebimento"],
+            bank_number=data["nossoNumero"],
+            bar_code=data["condigoBarras"],
+            typed_code=data["linhaDigitavel"],
+            txid=data["txid"],
+            simple_pix_code=data["pixCopiaECola"],
+        )
+
     def json_request_body(self):
         return {
             "codigoCobranca": self.charge_code,

--- a/Maestri.Back/common/helper/datetime_provider.py
+++ b/Maestri.Back/common/helper/datetime_provider.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+import pytz
+
+
+class DatetimeProvider:
+    @staticmethod
+    def now() -> datetime:
+        '''Timezone: Brazil/East"'''
+        tz = pytz.timezone("Brazil/East")
+        return datetime.now(tz)
+
+    @staticmethod
+    def utc_now() -> datetime:
+        """Timezone: UTC"""
+        return datetime.now(pytz.utc)

--- a/Maestri.Back/services/token/auth.py
+++ b/Maestri.Back/services/token/auth.py
@@ -1,7 +1,10 @@
 from common.constants.web_constants import WebConstants as wc
-from common.secrets.secrets import BANK
 from common.enums.request_type import RequestType
+from common.helper.datetime_provider import DatetimeProvider as dt
+from common.secrets.secrets import BANK
+from common.secrets.auth import AuthToken, AuthTokenModel
 from services.common.default_request import DefaultRequest
+import datetime
 
 
 class Auth:
@@ -11,6 +14,27 @@ class Auth:
         self._dr = dr
 
     def get_auth_token(self):
+        current_token = AuthToken.get_current_auth_token()
+
+        if current_token.IsValid():
+            print("current token")
+            return current_token.value
+
+        print("new token")
+        new_token = self.auth_token_request()
+        self._save_new_token(new_token)
+
+        return new_token
+
+    def _save_new_token(self, token_value: str):
+        token = AuthTokenModel(
+            value=token_value,
+            created=dt.utc_now(),
+            expire=dt.utc_now() + datetime.timedelta(minutes=30),
+        )
+        AuthToken.save_new_token(token)
+
+    def auth_token_request(self):
         request_body = (
             f"client_id=<{BANK.CLIENT_ID}>&client_secret=<{BANK.CLIENT_SECRET}>"
             "&scope=extrato.read boleto-cobranca.read boleto-cobranca.write pagamento-boleto.write pagamento-boleto.read pagamento-darf.write cob.write cob.read cobv.write cobv.read pix.write pix.read webhook.read webhook.write payloadlocation.write payloadlocation.read pagamento-pix.write pagamento-pix.read webhook-banking.write webhook-banking.read"
@@ -20,7 +44,7 @@ class Auth:
         response = self._dr.type_request(
             RequestType.POST,
             wc.OAUTH_TOKEN_REQUEST_URL,
-            {"Content-Type": "application/x-www-form-urlencoded"},
+            self.get_auth_header(),
             request_body,
         )
 


### PR DESCRIPTION
# Pipenv

Pipenv was added. Run `pipenv install` to add all projects dependencies.
- djangorestframework
- django
- requests
- pytz
- etc.

# DatetimeProvider

A new datetime provider was added. It's responsible for providing time. 
It should be used instead of the standard python datetime.datetime.now( )
Timezones by pytz: **Brazil/East** and **UTC**
- now( ) -> Brazil/East
- utc_now( ) -> UTC

# AuthToken

Auth tokens when created can be reutilized by later api calls. 
A token lifetime is currently 30 minutes and by its end a new one is created.
The auth token manager is within the secrets folder and it exposes the following methods:

- get_current_auth_token() -> returns the last created token
- save_new_token() -> saves a new auth token

AuthTokenModel represents all the Auth Tokens
- Fields:
  - token -> token value(str)
  - created -> datetime(utc) for when the token was created
  - expire -> datetime(utc) for when it is to expire

# Contracts

Some contracts signatures were changes following an update by a api provider 

- create_pix_payment
- pix_payment_response
- create_pix_slip_payment
- pix_slip_payment-response

# LineBreaks 

The linebreaks attribute for text files is **auto** and it avoids trouble

